### PR TITLE
Allow the user to set meta attributes in the splash request

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -166,6 +166,9 @@ To render the requests with Splash use 'splash' Request meta key::
      It is similar to SINGLE_SLOT policy, but can be different if you access
      other services on the same address as Splash.
 
+* ``meta['splash']['meta']`` allows to set meta attributes for the Splash
+  requests.
+
 Examples
 ========
 

--- a/scrapyjs/middleware.py
+++ b/scrapyjs/middleware.py
@@ -67,6 +67,7 @@ class SplashMiddleware(object):
 
         args = splash_options.setdefault('args', {})
         args.setdefault('url', request.url)
+
         body = json.dumps(args, ensure_ascii=False)
 
         if 'timeout' in args:
@@ -93,11 +94,14 @@ class SplashMiddleware(object):
         splash_base_url = splash_options.get('splash_url', self.splash_base_url)
         splash_url = urljoin(splash_base_url, endpoint)
 
+        splash_meta = meta.copy()
+        splash_meta.update(splash_options.get('meta', {}))
+
         req_rep = request.replace(
             url=splash_url,
             method='POST',
             body=body,
-
+            meta=splash_meta,
             # FIXME: original HTTP headers (including cookies)
             # are not respected.
             headers=Headers({'Content-Type': 'application/json'}),


### PR DESCRIPTION
This may be useful in general and specifically useful to avoid Hola to try to send requests to Splash, instead of Splash using Hola.